### PR TITLE
Search another size of image if default not exists

### DIFF
--- a/AdobeIms/Model/GetImage.php
+++ b/AdobeIms/Model/GetImage.php
@@ -18,8 +18,6 @@ use Magento\AdobeImsApi\Api\ConfigInterface;
  */
 class GetImage implements GetImageInterface
 {
-    private const IMAGE_SIZES = [50, 100, 115, 230, 138, 276];
-
     /**
      * @var LoggerInterface
      */
@@ -83,29 +81,21 @@ class GetImage implements GetImageInterface
     }
 
     /**
-     * Goes over all sizes and return first one available
+     * Get the profile image url of the requested size (or the biggest if requested size is not available)
      *
      * @param array $sizes
      * @param int $size
      */
     private function getImageSize(array $sizes, int $size): string
     {
-        $emptyResult = '';
-
-        if (array_values(array_keys($sizes)) !== self::IMAGE_SIZES) {
-            return $size;
+        if (empty($sizes)) {
+            return '';
         }
 
         if (isset($sizes[$size])) {
             return $sizes[$size];
         }
 
-        foreach (self::IMAGE_SIZES as $size) {
-            if (isset($sizes[$size])) {
-                return $sizes[$size];
-            }
-        }
-
-        return $emptyResult;
+        return end($sizes);
     }
 }

--- a/AdobeIms/Model/GetImage.php
+++ b/AdobeIms/Model/GetImage.php
@@ -90,14 +90,18 @@ class GetImage implements GetImageInterface
      */
     private function getImageSize(array $sizes, $size): string
     {
+        $size = '';
+
         if (isset($sizes[$size])) {
             return $sizes[$size];
         }
 
         foreach (self::IMAGE_SIZES as $size) {
             if (isset($sizes[$size])) {
-                return $sizes[$size];
+                $size =  $sizes[$size];
             }
         }
+
+        return $size;
     }
 }

--- a/AdobeIms/Model/GetImage.php
+++ b/AdobeIms/Model/GetImage.php
@@ -92,13 +92,17 @@ class GetImage implements GetImageInterface
     {
         $size = '';
 
+        if (array_values(array_keys($sizes)) !== self::IMAGE_SIZES) {
+            return $size;
+        }
+
         if (isset($sizes[$size])) {
             return $sizes[$size];
         }
 
         foreach (self::IMAGE_SIZES as $size) {
             if (isset($sizes[$size])) {
-                $size =  $sizes[$size];
+                return $sizes[$size];
             }
         }
 

--- a/AdobeIms/Model/GetImage.php
+++ b/AdobeIms/Model/GetImage.php
@@ -83,7 +83,7 @@ class GetImage implements GetImageInterface
     }
 
     /**
-     * Go over all sizes and get first one available
+     * Goes over all sizes and return first one available
      *
      * @param array $sizes
      * @param int $size

--- a/AdobeIms/Model/GetImage.php
+++ b/AdobeIms/Model/GetImage.php
@@ -88,9 +88,9 @@ class GetImage implements GetImageInterface
      * @param array $sizes
      * @param int $size
      */
-    private function getImageSize(array $sizes, $size): string
+    private function getImageSize(array $sizes, int $size): string
     {
-        $size = '';
+        $emptyResult = '';
 
         if (array_values(array_keys($sizes)) !== self::IMAGE_SIZES) {
             return $size;
@@ -106,6 +106,6 @@ class GetImage implements GetImageInterface
             }
         }
 
-        return $size;
+        return $emptyResult;
     }
 }

--- a/AdobeIms/Model/GetImage.php
+++ b/AdobeIms/Model/GetImage.php
@@ -18,6 +18,8 @@ use Magento\AdobeImsApi\Api\ConfigInterface;
  */
 class GetImage implements GetImageInterface
 {
+    private const IMAGE_SIZES = [50, 100, 115, 230, 138, 276];
+
     /**
      * @var LoggerInterface
      */
@@ -71,12 +73,31 @@ class GetImage implements GetImageInterface
 
             $curl->get($this->config->getProfileImageUrl());
             $result = $this->json->unserialize($curl->getBody());
-            $image = $result['user']['images'][$size];
+            $image = $this->getImageSize($result['user']['images'], $size);
         } catch (\Exception $exception) {
             $image = '';
             $this->logger->critical($exception);
         }
 
         return $image;
+    }
+
+    /**
+     * Go over all sizes and get first one available
+     *
+     * @param array $sizes
+     * @param int $size
+     */
+    private function getImageSize(array $sizes, $size): string
+    {
+        if (isset($sizes[$size])) {
+            return $sizes[$size];
+        }
+
+        foreach (self::IMAGE_SIZES as $size) {
+            if (isset($sizes[$size])) {
+                return $sizes[$size];
+            }
+        }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe IMS project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-ims#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-ims#4 Image isn't displayed next to account name in the Adobe Stock
2. ...

### Manual testing scenarios (*)

1.     Go to Content - Media Gallery
2.     Click on the "Search Adobe Stock" button
3.     Click "Sign in"

Expected result (*)

Image displays next to account name in the Adobe Stock